### PR TITLE
Improve error handling and docs

### DIFF
--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { NocoDBRequestError, NocoDBValidationError } from './errors';
+
+describe('custom error classes', () => {
+  it('creates NocoDBRequestError with properties', () => {
+    const err = new NocoDBRequestError('msg', 404, { ok: false });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('NocoDBRequestError');
+    expect(err.status).toBe(404);
+    expect(err.data).toEqual({ ok: false });
+  });
+
+  it('creates NocoDBValidationError with issues', () => {
+    const issues = [{ path: ['a'], message: 'bad' }];
+    const err = new NocoDBValidationError('fail', issues);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.issues).toBe(issues);
+  });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,21 @@
+export class NocoDBRequestError extends Error {
+  status?: number;
+  data?: unknown;
+
+  constructor(message: string, status?: number, data?: unknown) {
+    super(message);
+    this.name = 'NocoDBRequestError';
+    this.status = status;
+    this.data = data;
+  }
+}
+
+export class NocoDBValidationError extends Error {
+  issues: unknown[];
+
+  constructor(message: string, issues: unknown[]) {
+    super(message);
+    this.name = 'NocoDBValidationError';
+    this.issues = issues;
+  }
+}


### PR DESCRIPTION
## Summary
- add custom error classes
- use those errors in NocoDB client functions
- document pagination logic
- add unit tests for error classes

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68454de5f82083218ab67d66e3b7ac91