### PR TITLE
Remove NEXT_PUBLIC vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ If you use VS Code, the repository includes a preconfigured **dev container**. I
 
 The application expects a running NocoDB instance and a few environment variables. Create a `.env.local` file with content similar to:
 ```env
-NEXT_PUBLIC_NC_URL=http://localhost:8080
+NC_URL=http://localhost:8080
 NC_TOKEN=your_nocodb_token
-NEXT_PUBLIC_NOCODB_TABLE_NAME=youtubeTranscripts
-# NEXT_PUBLIC_NC_PROJECT_ID=phk8vxq6f1ev08h
+NOCODB_TABLE_NAME=youtubeTranscripts
+# NC_PROJECT_ID=phk8vxq6f1ev08h
 ```
 
 If you do not have NocoDB running locally you can start one with Docker:

--- a/SETUP.md
+++ b/SETUP.md
@@ -32,12 +32,12 @@ Create a `.env.local` file in the project root with the following content:
 
 ```env
 # NocoDB Configuration
-NEXT_PUBLIC_NC_URL=http://localhost:8080 //nocodb
+NC_URL=http://localhost:8080 # nocodb
 NC_TOKEN=your_nocodb_token_here
-NEXT_PUBLIC_NOCODB_TABLE_NAME=youtubeTranscripts
-NEXT_PUBLIC_NOCODB_PROJECT_ID=phk8vxq6f1ev08h
+NOCODB_TABLE_NAME=youtubeTranscripts
+NOCODB_PROJECT_ID=phk8vxq6f1ev08h
 ```
-//NEXT_PUBLIC_NC_URL=http://nocodb:8080
+#NC_URL=http://nocodb:8080
 
 
 

--- a/prompt.md
+++ b/prompt.md
@@ -161,7 +161,7 @@ Done:
   - Schema uses `.catchall(z.unknown())` to allow undefined fields.
 - **Data Fetching (`fetchVideos` in `src/lib/nocodb.ts`):**
   - Uses `axios` to fetch data.
-  - Reads `NEXT_PUBLIC_NC_URL`, `NC_TOKEN`, `NEXT_PUBLIC_NOCODB_TABLE_NAME` environment variables at runtime.
+  - Reads `NC_URL`, `NC_TOKEN`, `NOCODB_TABLE_NAME` environment variables at runtime.
 - **Testing (`src/lib/nocodb.test.ts`):**
   - All Vitest tests pass.
   - Mocks `axios` to simulate API responses.

--- a/src/app/test-nocodb/page.tsx
+++ b/src/app/test-nocodb/page.tsx
@@ -38,9 +38,9 @@ export default async function TestNocoDBPage() {
           <div>
             <strong>Troubleshooting Tips:</strong>
             <ul>
-              <li>Ensure your NocoDB instance is running at the URL specified in <code>NEXT_PUBLIC_NC_URL</code> (e.g., <code>http:</code>).</li>
-              <li>Verify the <code>NEXT_PUBLIC_NC_TOKEN</code> in your <code>.env.local</code> file is correct and has read permissions for the table.</li>
-              <li>Check that the table name (<code>NEXT_PUBLIC_NOCODB_TABLE_NAME</code> in <code>.env.local</code>, or default <code>youtubeTranscripts</code>) exists in your NocoDB project.</li>
+              <li>Ensure your NocoDB instance is running at the URL specified in <code>NC_URL</code> (e.g., <code>http:</code>).</li>
+              <li>Verify the <code>NC_TOKEN</code> in your <code>.env.local</code> file is correct and has read permissions for the table.</li>
+              <li>Check that the table name (<code>NOCODB_TABLE_NAME</code> in <code>.env.local</code>, or default <code>youtubeTranscripts</code>) exists in your NocoDB project.</li>
               <li>Confirm your Next.js development server was restarted after creating/modifying <code>.env.local</code> and changing the port in <code>package.json</code>.</li>
               <li>Look at the terminal console where you ran <code>pnpm dev</code> for more detailed error logs from the <code>fetchVideos</code> function.</li>
             </ul>

--- a/src/lib/nocodb.ts
+++ b/src/lib/nocodb.ts
@@ -25,24 +25,23 @@ export interface NocoDBConfig {
  * overrides. Throws if the URL or token are missing.
  */
 export function getNocoDBConfig(overrides: Partial<NocoDBConfig> = {}): NocoDBConfig {
-  const url = overrides.url || process.env.NEXT_PUBLIC_NC_URL;
-  const token =
-    overrides.token || process.env.NEXT_PUBLIC_NC_TOKEN || process.env.NC_TOKEN;
+  const url = overrides.url || process.env.NC_URL;
+  const token = overrides.token || process.env.NC_TOKEN;
   const projectId =
     overrides.projectId ||
-    process.env.NEXT_PUBLIC_NC_PROJECT_ID ||
-    process.env.NEXT_PUBLIC_NOCODB_PROJECT_ID ||
+    process.env.NC_PROJECT_ID ||
+    process.env.NOCODB_PROJECT_ID ||
     'phk8vxq6f1ev08h';
   const tableName =
     overrides.tableName ||
-    process.env.NEXT_PUBLIC_NOCODB_TABLE_NAME ||
+    process.env.NOCODB_TABLE_NAME ||
     'youtubeTranscripts';
 
   if (!url) {
-    throw new Error('NEXT_PUBLIC_NC_URL is not configured');
+    throw new Error('NC_URL is not configured');
   }
   if (!token) {
-    throw new Error('NEXT_PUBLIC_NC_TOKEN or NC_TOKEN is not configured');
+    throw new Error('NC_TOKEN is not configured');
   }
 
   return { url, token, projectId, tableName };

--- a/src/types/next.d.ts
+++ b/src/types/next.d.ts
@@ -61,12 +61,12 @@ declare module 'next/image' {
 declare namespace NodeJS {
   interface ProcessEnv {
     NODE_ENV: 'development' | 'production' | 'test';
-    NEXT_PUBLIC_NC_URL?: string;
-    NEXT_PUBLIC_NC_TOKEN?: string;
+    NC_URL?: string;
     NC_TOKEN?: string;
-    NEXT_PUBLIC_NC_PROJECT_ID?: string;
-    NEXT_PUBLIC_NOCODB_PROJECT_ID?: string;
-    NEXT_PUBLIC_NOCODB_TABLE_NAME?: string;
+    NC_PROJECT_ID?: string;
+    NOCODB_PROJECT_ID?: string;
+    NOCODB_TABLE_NAME?: string;
+    NOCODB_TABLE_ID?: string;
   }
 }
 

--- a/status.md
+++ b/status.md
@@ -52,9 +52,9 @@
   - Refined `VideoSchema` and `NocoDBResponseSchema` (Zod) for robust API response validation:
     - `ThumbHigh` field transformed from NocoDB attachment array to a direct image URL string (or `null`).
     - Optional text fields (`Channel`, `Description`, `PersonalComment`) and `ImportanceRating` now default to `null` if not present in API response, resolving test inconsistencies.
-  - `fetchVideos` function to get and validate video records, dynamically reading environment variables (`NEXT_PUBLIC_NC_URL`, `NC_TOKEN`, `NEXT_PUBLIC_NOCODB_TABLE_NAME`).
+  - `fetchVideos` function to get and validate video records, dynamically reading environment variables (`NC_URL`, `NC_TOKEN`, `NOCODB_TABLE_NAME`).
   - Vitest tests (`src/lib/nocodb.test.ts`): All tests passing. Comprehensive mocking of Axios for various scenarios (success, API errors, invalid data structure, missing env vars). Tests confirm correct parsing of refined schema, including optional fields.
-   - Local NocoDB connection settings for development/testing: `NEXT_PUBLIC_NC_URL=http://nocodb:8080` (Docker network hostname), `projectId='phk8vxq6f1ev08h'` (hardcoded in `nocodb.ts`), `NC_TOKEN=<user_provided_token>`, `NEXT_PUBLIC_NOCODB_TABLE_NAME=youtubeTranscripts` (user to set these in `.env.local`).
+   - Local NocoDB connection settings for development/testing: `NC_URL=http://nocodb:8080` (Docker network hostname), `projectId='phk8vxq6f1ev08h'` (hardcoded in `nocodb.ts`), `NC_TOKEN=<user_provided_token>`, `NOCODB_TABLE_NAME=youtubeTranscripts` (user to set these in `.env.local`).
 - **NocoDB API Client (`src/lib/nocodb.ts`) String-to-Array Parsing Fix:**
   - Resolved Zod parsing errors where NocoDB API returned newline-separated strings for fields expected as arrays in `fetchVideoByVideoId`.
   - Introduced `stringToArrayOrNullPreprocessor`: Converts newline-separated strings to `string[]`, trims values, and handles empty/null inputs. Applied to fields like `MemorableQuotes`, `MemorableTakeaways`, `Hashtags`, `KeyExamples`, `InvestableAssets`, `PrimarySources`, `TechnicalTerms`.


### PR DESCRIPTION
## Summary
- drop old NEXT_PUBLIC environment variables
- update docs and types to use NC_URL, NC_TOKEN and friends

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455056b7b08321a2f495e0d25694f0