### PR TITLE
Add unit & integration tests

### DIFF
--- a/src/__mocks__/next/image.ts
+++ b/src/__mocks__/next/image.ts
@@ -1,0 +1,4 @@
+export default function Image(props: any) {
+  // eslint-disable-next-line @next/next/no-img-element
+  return <img {...props} />;
+}

--- a/src/components/StarRating.test.tsx
+++ b/src/components/StarRating.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StarRating } from './StarRating';
+
+describe('StarRating component', () => {
+  it('calls onChange with selected rating', async () => {
+    const handleChange = vi.fn(() => Promise.resolve());
+    const { getAllByRole } = render(<StarRating value={null} onChange={handleChange} />);
+    const buttons = getAllByRole('button');
+    await userEvent.click(buttons[2]);
+    expect(handleChange).toHaveBeenCalledWith(3);
+  });
+
+  it('shows read-only state', () => {
+    const { getAllByRole } = render(<StarRating value={4} readOnly />);
+    const buttons = getAllByRole('button');
+    buttons.forEach(btn => expect(btn).toHaveAttribute('tabindex', '-1'));
+  });
+});

--- a/src/components/video-card.test.tsx
+++ b/src/components/video-card.test.tsx
@@ -1,0 +1,38 @@
+vi.mock("next/image", () => ({ __esModule: true, default: (props: any) => (<img {...props} />) }));
+import { render } from '@testing-library/react';
+import { VideoCard } from './video-card';
+import type { VideoListItem } from '@/lib/nocodb';
+
+const sample: VideoListItem = {
+  Id: 1,
+  Title: 'Test Video',
+  VideoID: 'abc123',
+  ThumbHigh: 'http://example.com/thumb.jpg',
+  Channel: 'Channel',
+  Description: 'Desc',
+  VideoGenre: null,
+  Persons: null,
+  Companies: null,
+  Indicators: null,
+  Trends: null,
+  InvestableAssets: null,
+  TickerSymbol: null,
+  Institutions: null,
+  EventsFairs: null,
+  DOIs: null,
+  Hashtags: null,
+  MainTopic: null,
+  PrimarySources: null,
+  Sentiment: null,
+  SentimentReason: null,
+  TechnicalTerms: null,
+  Speaker: null,
+};
+
+describe('VideoCard', () => {
+  it('renders link to video page', () => {
+    const { getByRole } = render(<VideoCard video={sample} />);
+    const link = getByRole('link');
+    expect(link).toHaveAttribute('href', '/video/abc123');
+  });
+});

--- a/src/hooks/use-mounted.test.tsx
+++ b/src/hooks/use-mounted.test.tsx
@@ -1,0 +1,9 @@
+import { renderHook } from '@testing-library/react';
+import { useMounted } from './use-mounted';
+
+describe('useMounted', () => {
+  it('returns true after mount', () => {
+    const { result } = renderHook(() => useMounted());
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/lib/nocodb.test.ts
+++ b/src/lib/nocodb.test.ts
@@ -1,0 +1,35 @@
+import { getNocoDBConfig } from './nocodb';
+
+describe('getNocoDBConfig', () => {
+  const env = process.env;
+  beforeEach(() => {
+    process.env = { ...env };
+  });
+  afterEach(() => {
+    process.env = env;
+  });
+
+  it('throws if no url or token', () => {
+    delete process.env.NOCODB_URL;
+    delete process.env.NC_URL;
+    delete process.env.NOCODB_AUTH_TOKEN;
+    delete process.env.NC_TOKEN;
+    expect(() => getNocoDBConfig()).toThrow();
+  });
+
+  it('uses env variables', () => {
+    process.env.NOCODB_URL = 'http://test';
+    process.env.NOCODB_AUTH_TOKEN = 't';
+    const cfg = getNocoDBConfig();
+    expect(cfg.url).toBe('http://test');
+    expect(cfg.token).toBe('t');
+  });
+
+  it('overrides with arguments', () => {
+    process.env.NOCODB_URL = 'http://env';
+    process.env.NOCODB_AUTH_TOKEN = 't';
+    const cfg = getNocoDBConfig({ url: 'http://arg', token: 'x' });
+    expect(cfg.url).toBe('http://arg');
+    expect(cfg.token).toBe('x');
+  });
+});

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,7 @@
+import { cn } from './utils';
+
+describe('cn utility', () => {
+  it('merges class names', () => {
+    expect(cn('a', false && 'b', 'c')).toBe('a c');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest mocks for `next/image`
- test utility helpers and NocoDB config
- add component tests for StarRating and VideoCard
- test `useMounted` hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848503856308321a0589127235b68ee