### PR TITLE
Fix NocoDB config & v2 API paths

### DIFF
--- a/src/__mocks__/next/image.ts
+++ b/src/__mocks__/next/image.ts
@@ -1,4 +1,0 @@
-export default function Image(props: any) {
-  // eslint-disable-next-line @next/next/no-img-element
-  return <img {...props} />;
-}

--- a/src/__mocks__/next/image.tsx
+++ b/src/__mocks__/next/image.tsx
@@ -1,0 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function Image(props: any) {
+  // eslint-disable-next-line @next/next/no-img-element
+  return <img {...props} alt={props.alt || ''} />;
+}

--- a/src/components/video-card.test.tsx
+++ b/src/components/video-card.test.tsx
@@ -1,4 +1,5 @@
-vi.mock("next/image", () => ({ __esModule: true, default: (props: any) => (<img {...props} />) }));
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+vi.mock("next/image", () => ({ __esModule: true, default: (props: any) => (<img {...props} alt={props.alt || ''} />) }));
 import { render } from '@testing-library/react';
 import { VideoCard } from './video-card';
 import type { VideoListItem } from '@/lib/nocodb';

--- a/src/types/next.d.ts
+++ b/src/types/next.d.ts
@@ -67,6 +67,11 @@ declare namespace NodeJS {
     NOCODB_PROJECT_ID?: string;
     NOCODB_TABLE_NAME?: string;
     NOCODB_TABLE_ID?: string;
+    NC_TABLE_ID?: string;
+    NEXT_PUBLIC_NC_URL?: string;
+    NEXT_PUBLIC_NC_TOKEN?: string;
+    NEXT_PUBLIC_NOCODB_URL?: string;
+    NEXT_PUBLIC_NOCODB_AUTH_TOKEN?: string;
   }
 }
 


### PR DESCRIPTION
## Summary
- allow NEXT_PUBLIC env vars in NocoDB config and support tableId
- use NocoDB API v2 routes throughout nocodb.ts
- adjust tests/mocks for lint compliance

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68516d3f7a388321886b4c17d8e21c3d