### PR TITLE
Maintain video filter across navigation

### DIFF
--- a/src/app/video/[videoId]/page.tsx
+++ b/src/app/video/[videoId]/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 import { fetchVideoByVideoId, fetchAllVideos } from '@/lib/nocodb';
+import type { FilterOption } from '@/lib/filterVideos';
+import { filterVideos } from '@/lib/filterVideos';
 import { notFound } from 'next/navigation';
 import { VideoDetailPageContent } from './VideoDetailPageContent';
 
@@ -25,9 +27,9 @@ export async function generateMetadata({ params }: VideoDetailPageProps): Promis
   };
 }
 
-export default async function VideoDetailPage({ 
-  params: paramsProp, 
-  searchParams: searchParamsProp = { sort: '-CreatedAt' } 
+export default async function VideoDetailPage({
+  params: paramsProp,
+  searchParams: searchParamsProp = { sort: '-CreatedAt' }
 }: VideoDetailPageProps) {
   // Ensure both params and searchParams are resolved
   const [params, searchParams] = await Promise.all([
@@ -59,21 +61,37 @@ export default async function VideoDetailPage({
     fields: ['Id', 'VideoID', 'Title'], // Kept fields consistent with original
   });
 
-  // The if (!video) check was here, but it's now redundant as it's performed earlier.
-  
-  const validVideoListItems = Array.isArray(allVideoListItems) ? allVideoListItems : [];
+  // Build selected filters from query params
+  const filterValues = Array.isArray(searchParams.f)
+    ? searchParams.f
+    : searchParams.f
+      ? [searchParams.f]
+      : [];
+  const selectedFilters: FilterOption[] = filterValues
+    .map((p) => {
+      const [type, ...rest] = p.split(':');
+      const value = decodeURIComponent(rest.join(':'));
+      if (!type || !value) return null;
+      return { label: value, value, type } as FilterOption;
+    })
+    .filter(Boolean) as FilterOption[];
+
+  const filteredList = filterVideos(
+    Array.isArray(allVideoListItems) ? allVideoListItems : [],
+    selectedFilters
+  );
 
   
   
   
-  const currentVideoIndexInList = validVideoListItems.findIndex(item => item.VideoID === video.VideoID);
+  const currentVideoIndexInList = filteredList.findIndex(item => item.VideoID === video.VideoID);
 
   let previousVideoData: { Id: string; Title: string | null } | null = null;
   let nextVideoData: { Id: string; Title: string | null } | null = null;
 
   if (currentVideoIndexInList !== -1) {
-    const prevItem = currentVideoIndexInList > 0 ? validVideoListItems[currentVideoIndexInList - 1] : null;
-    const nextItem = currentVideoIndexInList < validVideoListItems.length - 1 ? validVideoListItems[currentVideoIndexInList + 1] : null;
+    const prevItem = currentVideoIndexInList > 0 ? filteredList[currentVideoIndexInList - 1] : null;
+    const nextItem = currentVideoIndexInList < filteredList.length - 1 ? filteredList[currentVideoIndexInList + 1] : null;
 
     if (prevItem?.VideoID) {
       previousVideoData = { Id: prevItem.VideoID, Title: prevItem.Title || null };
@@ -90,7 +108,7 @@ export default async function VideoDetailPage({
   return (
     <VideoDetailPageContent 
       video={video} 
-      allVideos={validVideoListItems} 
+      allVideos={filteredList}
       previousVideo={previousVideoData}
       nextVideo={nextVideoData}
     />

--- a/src/components/video-card.tsx
+++ b/src/components/video-card.tsx
@@ -5,17 +5,20 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import type { VideoListItem } from '@/lib/nocodb'; 
 
 interface VideoCardProps {
-  video: VideoListItem; 
-  priority?: boolean; 
+  video: VideoListItem;
+  href?: string;
+  priority?: boolean;
 }
 
-export function VideoCard({ video, priority = false }: VideoCardProps) {
+export function VideoCard({ video, href, priority = false }: VideoCardProps) {
   
   const thumbnailUrl = video.ThumbHigh && typeof video.ThumbHigh === 'string' ? video.ThumbHigh : null;
 
+  const link = href || `/video/${video.VideoID}`;
+
   return (
-    
-    <Link href={`/video/${video.VideoID}`} passHref className="block hover:shadow-lg transition-shadow duration-200 rounded-lg h-full">
+
+    <Link href={link} passHref className="block hover:shadow-lg transition-shadow duration-200 rounded-lg h-full">
       <Card className="w-full flex flex-col h-full bg-card text-card-foreground p-0">
         <CardHeader className="p-0 rounded-t-lg overflow-hidden">
           {thumbnailUrl ? (

--- a/src/lib/filterVideos.ts
+++ b/src/lib/filterVideos.ts
@@ -1,0 +1,95 @@
+export interface FilterOption {
+  label: string;
+  value: string;
+  type:
+    | 'person'
+    | 'company'
+    | 'genre'
+    | 'indicator'
+    | 'trend'
+    | 'asset'
+    | 'ticker'
+    | 'institution'
+    | 'event'
+    | 'doi'
+    | 'hashtag'
+    | 'mainTopic'
+    | 'primarySource'
+    | 'sentiment'
+    | 'sentimentReason'
+    | 'channel'
+    | 'description'
+    | 'technicalTerm'
+    | 'speaker';
+}
+
+import type { VideoListItem } from '@/lib/nocodb';
+
+/**
+ * Filter a list of videos based on selected filter options.
+ */
+export function filterVideos<T extends VideoListItem>(videos: T[], selectedFilters: FilterOption[]): T[] {
+  if (!selectedFilters.length) return videos;
+  return videos.filter((v) => {
+    return selectedFilters.every((f) => {
+      if (f.type === 'person') {
+        return v.Persons?.some((p) => (typeof p === 'string' ? p : p?.Title || p?.name) === f.value);
+      }
+      if (f.type === 'company') {
+        return v.Companies?.some((c) => (typeof c === 'string' ? c : c?.Title || c?.name) === f.value);
+      }
+      if (f.type === 'genre') {
+        return v.VideoGenre === f.value;
+      }
+      if (f.type === 'indicator') {
+        return v.Indicators?.some((i) => (typeof i === 'string' ? i : i?.Title || i?.name) === f.value);
+      }
+      if (f.type === 'trend') {
+        return v.Trends?.some((t) => (typeof t === 'string' ? t : t?.Title || t?.name) === f.value);
+      }
+      if (f.type === 'asset') {
+        return v.InvestableAssets?.includes(f.value);
+      }
+      if (f.type === 'ticker') {
+        return v.TickerSymbol === f.value;
+      }
+      if (f.type === 'institution') {
+        return v.Institutions?.some((inst) => (typeof inst === 'string' ? inst : inst?.Title || inst?.name) === f.value);
+      }
+      if (f.type === 'event') {
+        return v.EventsFairs?.includes(f.value);
+      }
+      if (f.type === 'doi') {
+        return v.DOIs?.includes(f.value);
+      }
+      if (f.type === 'hashtag') {
+        return v.Hashtags?.includes(f.value);
+      }
+      if (f.type === 'mainTopic') {
+        return v.MainTopic === f.value;
+      }
+      if (f.type === 'primarySource') {
+        return v.PrimarySources?.includes(f.value);
+      }
+      if (f.type === 'sentiment') {
+        return String(v.Sentiment ?? '') === f.value;
+      }
+      if (f.type === 'sentimentReason') {
+        return v.SentimentReason === f.value;
+      }
+      if (f.type === 'channel') {
+        return v.Channel === f.value;
+      }
+      if (f.type === 'description') {
+        return v.Description === f.value;
+      }
+      if (f.type === 'technicalTerm') {
+        return v.TechnicalTerms?.includes(f.value);
+      }
+      if (f.type === 'speaker') {
+        return v.Speaker === f.value;
+      }
+      return true;
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `filterVideos` helper to apply filters consistently
- persist filters in URL in `VideoListClient`
- pass query string to `VideoCard` links
- compute next/previous videos using filtered list in video detail page

## Testing
- `pnpm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68518282bc94832182a9970ec3599f64