### PR TITLE
Refactor helpers and filter logic

### DIFF
--- a/status.md
+++ b/status.md
@@ -157,3 +157,8 @@
 - [x] 3. Simplify filter option collection in `video-list-client.tsx` using a configuration-driven approach.
 - [x] 4. Update existing files to use new helpers without changing functionality.
 - [x] 5. Run and pass tests using `pnpm test`.
+- [x] 6. Extract numeric ID resolution into shared `resolveNumericId` helper.
+- [x] 7. Create `createRequestError` to centralize axios error handling.
+- [x] 8. Refactor `updateVideo` and `deleteVideo` to use these helpers.
+- [x] 9. Consolidate video filtering logic using a unified configuration.
+- [x] 10. Run `pnpm test` to ensure refactor maintains behavior.


### PR DESCRIPTION
## Summary
- share `resolveNumericId` and `createRequestError` helpers in `nocodb.ts`
- simplify `updateVideo` and `deleteVideo` using new helpers
- centralize filter configuration in `video-list-client.tsx`
- update status with completed tasks

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685549053984832199992114aef93058