### PR TITLE
feat(saved): add per-video JSON download and Saved playlist overview with client cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A modern, responsive web application for browsing, searching, and interacting wi
   - Tag-based search interface similar to macOS Finder
   - Category-based filtering with visual icons
   - Real-time search across the complete video database
+- **Saved Playlist Overview**: Toggle between summaries from NocoDB and a YouTube playlist feed with client-side caching
 - **Code Optimization**: The NocoDB client has been extensively refactored to eliminate code duplication and improve maintainability:
   - **Schema Preprocessing**: Created reusable preprocessing utilities (`preprocessors` object) to reduce schema definition code by ~70%
   - **API Function Consolidation**: Unified duplicate fetch functions into a single `fetchSingleVideo` function with consistent behavior
@@ -111,6 +112,9 @@ If you use VS Code, the repository includes a preconfigured **dev container**. I
    NC_TOKEN=your_nocodb_token
    NOCODB_PROJECT_ID=your_project_id          # e.g. phk8vxq6f1ev08h
    NOCODB_TABLE_ID=your_table_id              # e.g. m1lyoeqptp7fq5z (opaque v2 id)
+   # YouTube Saved Playlist (for the "Saved" overview)
+   YOUTUBE_API_KEY=your_youtube_api_key
+   YOUTUBE_SAVED_PLAYLIST_ID=your_playlist_id
    # Optional: human-readable slug for diagnostics/logging
    # NOCODB_TABLE_NAME=youtubeTranscripts
    ```
@@ -132,6 +136,8 @@ NC_URL=http://localhost:8080
 NC_TOKEN=your_nocodb_token
 NOCODB_PROJECT_ID=phk8vxq6f1ev08h
 NOCODB_TABLE_ID=m1lyoeqptp7fq5z
+YOUTUBE_API_KEY=your_youtube_api_key
+YOUTUBE_SAVED_PLAYLIST_ID=your_playlist_id
 # Optional diagnostic slug
 # NOCODB_TABLE_NAME=youtubeTranscripts
 ```

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import Link from 'next/link';
+import { useState } from 'react';
 import { Settings } from 'lucide-react';
 import { SearchComponent } from '@/shared/components/search-component';
 import { PWAInstallPrompt } from '@/shared/components/pwa-install-prompt';
+import { Button } from '@/shared/components/ui/button';
+import { SavedPlaylistClient } from '@/features/saved/components/SavedPlaylistClient';
 
 /**
  * Client-side HomePage Component
@@ -13,6 +16,8 @@ import { PWAInstallPrompt } from '@/shared/components/pwa-install-prompt';
  * to intercept /api/videos requests and serve data from IndexedDB when offline.
  */
 export function HomePageClient() {
+  const [activeView, setActiveView] = useState<'summaries' | 'saved'>('summaries');
+
   return (
     <div className="min-h-screen bg-neutral-900 text-neutral-50 p-4 md:p-8 font-plex-sans">
       <div className="container mx-auto max-w-5xl">
@@ -31,10 +36,31 @@ export function HomePageClient() {
           </div>
         </div>
 
-        <div className="search-component-wrapper">
-          {/* No initialVideos - let SearchComponent fetch client-side */}
-          <SearchComponent initialVideos={[]} />
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <Button
+            type="button"
+            variant={activeView === 'summaries' ? 'default' : 'secondary'}
+            onClick={() => setActiveView('summaries')}
+          >
+            Summaries
+          </Button>
+          <Button
+            type="button"
+            variant={activeView === 'saved' ? 'default' : 'secondary'}
+            onClick={() => setActiveView('saved')}
+          >
+            Saved
+          </Button>
         </div>
+
+        {activeView === 'summaries' ? (
+          <div className="search-component-wrapper">
+            {/* No initialVideos - let SearchComponent fetch client-side */}
+            <SearchComponent initialVideos={[]} />
+          </div>
+        ) : (
+          <SavedPlaylistClient />
+        )}
 
         {/* PWA Install Prompt */}
         <PWAInstallPrompt />

--- a/src/app/api/videos/[videoId]/download/route.ts
+++ b/src/app/api/videos/[videoId]/download/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+
+import { fetchVideoByVideoId } from '@/features/videos/api/nocodb';
+
+// This endpoint returns a single video as a downloadable JSON file so beginners can
+// see the exact data that is stored in NocoDB.
+export async function GET(
+  _request: Request,
+  { params }: { params: { videoId: string } },
+) {
+  const video = await fetchVideoByVideoId(params.videoId);
+
+  if (!video) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Video not found',
+      },
+      { status: 404 },
+    );
+  }
+
+  const body = JSON.stringify(video, null, 2);
+
+  return new NextResponse(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Disposition': `attachment; filename="video-${params.videoId}.json"`,
+    },
+  });
+}

--- a/src/app/api/youtube/playlist/route.ts
+++ b/src/app/api/youtube/playlist/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+
+import { buildPlaylistItemsUrl, mapPlaylistResponse } from '@/features/saved/youtube';
+
+// Keep the API lightweight: fetch a page of playlist items and forward them to the client.
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const pageToken = searchParams.get('pageToken') ?? undefined;
+  const playlistId = searchParams.get('playlistId') ?? process.env.YOUTUBE_SAVED_PLAYLIST_ID;
+  const apiKey = process.env.YOUTUBE_API_KEY;
+
+  if (!playlistId || !apiKey) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Missing YOUTUBE_API_KEY or YOUTUBE_SAVED_PLAYLIST_ID environment variables.',
+      },
+      { status: 400 },
+    );
+  }
+
+  const url = buildPlaylistItemsUrl({ apiKey, playlistId, pageToken });
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: `YouTube API error: ${response.status} ${response.statusText}`,
+      },
+      { status: response.status },
+    );
+  }
+
+  const data = (await response.json()) as unknown;
+  const mapped = mapPlaylistResponse(data as Parameters<typeof mapPlaylistResponse>[0], playlistId);
+
+  return NextResponse.json({
+    success: true,
+    items: mapped.items,
+    nextPageToken: mapped.nextPageToken ?? null,
+  });
+}

--- a/src/features/saved/components/SavedPlaylistClient.tsx
+++ b/src/features/saved/components/SavedPlaylistClient.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { Button } from '@/shared/components/ui/button';
+import { Card, CardContent } from '@/shared/components/ui/card';
+import { Loader2 } from 'lucide-react';
+
+import { cachePlaylistItems, getCachedPlaylistItems, getSavedMetadata } from '../db/client';
+import type { SavedPlaylistItem } from '../types';
+import { SavedVideoCard } from './SavedVideoCard';
+
+type PlaylistResponse = {
+  success: boolean;
+  items: SavedPlaylistItem[];
+  nextPageToken?: string;
+  error?: string;
+};
+
+export function SavedPlaylistClient() {
+  const [items, setItems] = useState<SavedPlaylistItem[]>([]);
+  const [nextPageToken, setNextPageToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [lastSync, setLastSync] = useState<string | null>(null);
+  const [cacheBytes, setCacheBytes] = useState<number | null>(null);
+
+  const totalVideos = items.length;
+
+  const refreshMetadata = useCallback(async () => {
+    const [cachedSync, cachedBytes] = await Promise.all([
+      getSavedMetadata('lastSync'),
+      getSavedMetadata('totalCacheBytes'),
+    ]);
+
+    setLastSync(typeof cachedSync === 'string' ? cachedSync : null);
+    setCacheBytes(typeof cachedBytes === 'number' ? cachedBytes : null);
+  }, []);
+
+  const fetchPlaylist = useCallback(
+    async (append: boolean) => {
+      setIsLoading(true);
+      setErrorMessage(null);
+
+      try {
+        const params = new URLSearchParams();
+        if (append && nextPageToken) {
+          params.set('pageToken', nextPageToken);
+        }
+
+        const response = await fetch(`/api/youtube/playlist?${params.toString()}`);
+        const data = (await response.json()) as PlaylistResponse;
+
+        if (!data.success) {
+          setErrorMessage(data.error ?? 'Failed to load saved playlist.');
+          return;
+        }
+
+        setNextPageToken(data.nextPageToken ?? null);
+
+        setItems((prev) => {
+          const nextItems = append ? [...prev, ...data.items] : data.items;
+          cachePlaylistItems(nextItems).then(refreshMetadata);
+          return nextItems;
+        });
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : 'Unknown error loading playlist.');
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [nextPageToken, refreshMetadata],
+  );
+
+  useEffect(() => {
+    // Load cached items first so the UI shows something even before the API call finishes.
+    getCachedPlaylistItems()
+      .then((cached) => {
+        if (cached.length > 0) {
+          setItems(cached);
+        }
+      })
+      .catch(() => {
+        // Ignore cache errors; the network fetch will still run.
+      })
+      .finally(() => {
+        refreshMetadata();
+        fetchPlaylist(false);
+      });
+  }, [fetchPlaylist, refreshMetadata]);
+
+  const formattedCacheSize = useMemo(() => {
+    if (!cacheBytes) return '0 MB';
+    const mb = cacheBytes / (1024 * 1024);
+    return `${mb.toFixed(1)} MB`;
+  }, [cacheBytes]);
+
+  return (
+    <div className="space-y-4">
+      <Card className="bg-neutral-900 border-neutral-800">
+        <CardContent className="p-4 text-sm text-neutral-300 space-y-1">
+          <p>
+            {totalVideos} saved videos cached locally. Cache size: {formattedCacheSize}.
+          </p>
+          <p>Last sync: {lastSync ? new Date(lastSync).toLocaleString() : 'Never'}</p>
+        </CardContent>
+      </Card>
+
+      {errorMessage && (
+        <Card className="bg-red-950 border-red-900">
+          <CardContent className="p-4 text-sm text-red-200">{errorMessage}</CardContent>
+        </Card>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((item) => (
+          <SavedVideoCard key={item.id} item={item} />
+        ))}
+      </div>
+
+      <div className="flex justify-center">
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => fetchPlaylist(true)}
+          disabled={isLoading || !nextPageToken}
+        >
+          {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          {nextPageToken ? 'Load More' : 'All videos loaded'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/saved/components/SavedVideoCard.tsx
+++ b/src/features/saved/components/SavedVideoCard.tsx
@@ -1,0 +1,54 @@
+import Image from 'next/image';
+
+import type { SavedPlaylistItem } from '../types';
+
+type SavedVideoCardProps = {
+  item: SavedPlaylistItem;
+};
+
+export function SavedVideoCard({ item }: SavedVideoCardProps) {
+  const videoUrl = item.videoId ? `https://www.youtube.com/watch?v=${item.videoId}` : '#';
+
+  return (
+    <div className="w-full flex flex-col h-full rounded-lg shadow-sm bg-neutral-800/50">
+      <div className="p-0 rounded-t-lg overflow-hidden">
+        {item.thumbnailUrl ? (
+          <div className="relative w-full aspect-video">
+            <Image
+              src={item.thumbnailUrl}
+              alt={`Thumbnail for ${item.title}`}
+              fill
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              className="object-cover object-top rounded-t-lg"
+            />
+          </div>
+        ) : (
+          <div className="relative w-full aspect-video flex items-center justify-center rounded-t-lg bg-neutral-700/70">
+            <span className="text-xs text-neutral-300">No Thumbnail</span>
+          </div>
+        )}
+      </div>
+      <div className="p-2 flex-grow flex flex-col justify-between rounded-b-lg">
+        <div>
+          <h3 className="text-base font-semibold line-clamp-2 mb-0.5 text-neutral-100" title={item.title}>
+            {item.title}
+          </h3>
+          <p className="text-xs truncate mb-0.5 text-neutral-400" title={item.channelTitle}>
+            {item.channelTitle}
+          </p>
+        </div>
+        <div className="mt-2 flex justify-end">
+          {/* Link to the actual YouTube video so users can download via their preferred method */}
+          <a
+            href={videoUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs text-neutral-300 hover:text-neutral-50 underline underline-offset-4"
+          >
+            Open on YouTube
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/saved/db/client.ts
+++ b/src/features/saved/db/client.ts
@@ -1,0 +1,63 @@
+import { openDB } from 'idb';
+
+import type { SavedPlaylistItem } from '../types';
+import type { SavedPlaylistDBSchema } from './schema';
+import { SAVED_DB_NAME, SAVED_DB_VERSION, SAVED_CACHE_LIMIT_BYTES } from './schema';
+
+function estimateBytes(value: unknown) {
+  // Approximate size using JSON length; good enough for a client-side budget check.
+  return new TextEncoder().encode(JSON.stringify(value)).length;
+}
+
+async function getDb() {
+  return openDB<SavedPlaylistDBSchema>(SAVED_DB_NAME, SAVED_DB_VERSION, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains('playlistItems')) {
+        const store = db.createObjectStore('playlistItems', { keyPath: 'id' });
+        store.createIndex('by-videoId', 'videoId');
+        store.createIndex('by-publishedAt', 'publishedAt');
+      }
+
+      if (!db.objectStoreNames.contains('metadata')) {
+        db.createObjectStore('metadata');
+      }
+    },
+  });
+}
+
+export async function getCachedPlaylistItems() {
+  const db = await getDb();
+  return db.getAll('playlistItems');
+}
+
+export async function getSavedMetadata(key: string) {
+  const db = await getDb();
+  return db.get('metadata', key);
+}
+
+export async function cachePlaylistItems(items: SavedPlaylistItem[]) {
+  const estimatedBytes = estimateBytes(items);
+
+  if (estimatedBytes > SAVED_CACHE_LIMIT_BYTES) {
+    return {
+      cached: false,
+      reason: 'Playlist items exceed the 5GB cache limit.',
+    };
+  }
+
+  const db = await getDb();
+  const tx = db.transaction(['playlistItems', 'metadata'], 'readwrite');
+
+  const playlistStore = tx.objectStore('playlistItems');
+  const metadataStore = tx.objectStore('metadata');
+
+  await playlistStore.clear();
+  await Promise.all(items.map((item) => playlistStore.put(item)));
+
+  await metadataStore.put(estimatedBytes, 'totalCacheBytes');
+  await metadataStore.put(new Date().toISOString(), 'lastSync');
+
+  await tx.done;
+
+  return { cached: true, estimatedBytes };
+}

--- a/src/features/saved/db/schema.ts
+++ b/src/features/saved/db/schema.ts
@@ -1,0 +1,26 @@
+import type { DBSchema } from 'idb';
+
+import type { SavedPlaylistItem } from '../types';
+
+// This small schema keeps the "Saved" playlist data on the client so we can show it fast
+// without re-fetching from the YouTube API every time.
+export interface SavedPlaylistDBSchema extends DBSchema {
+  playlistItems: {
+    key: string; // Playlist item ID from YouTube
+    value: SavedPlaylistItem;
+    indexes: {
+      'by-videoId': string;
+      'by-publishedAt': string;
+    };
+  };
+  metadata: {
+    key: string; // 'lastSync', 'totalCacheBytes'
+    value: unknown;
+  };
+}
+
+export const SAVED_DB_NAME = 'yt-viewer-saved-playlist';
+export const SAVED_DB_VERSION = 1;
+
+// 5 GB cache limit to align with the product requirement.
+export const SAVED_CACHE_LIMIT_BYTES = 5 * 1024 * 1024 * 1024;

--- a/src/features/saved/types.ts
+++ b/src/features/saved/types.ts
@@ -1,0 +1,9 @@
+export type SavedPlaylistItem = {
+  id: string;
+  videoId: string;
+  title: string;
+  channelTitle: string;
+  thumbnailUrl: string | null;
+  publishedAt: string | null;
+  playlistId: string;
+};

--- a/src/features/saved/youtube.test.ts
+++ b/src/features/saved/youtube.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPlaylistItemsUrl, mapPlaylistResponse } from './youtube';
+
+describe('saved playlist helpers', () => {
+  it('buildPlaylistItemsUrl includes required params', () => {
+    const url = buildPlaylistItemsUrl({
+      apiKey: 'test-key',
+      playlistId: 'playlist-123',
+      pageToken: 'token-1',
+      maxResults: 25,
+    });
+
+    expect(url).toContain('playlistItems');
+    expect(url).toContain('part=snippet');
+    expect(url).toContain('maxResults=25');
+    expect(url).toContain('playlistId=playlist-123');
+    expect(url).toContain('pageToken=token-1');
+    expect(url).toContain('key=test-key');
+  });
+
+  it('mapPlaylistResponse normalizes playlist items', () => {
+    const result = mapPlaylistResponse(
+      {
+        nextPageToken: 'next-1',
+        items: [
+          {
+            id: 'item-1',
+            snippet: {
+              title: 'Saved video',
+              channelTitle: 'Channel',
+              publishedAt: '2024-01-01T00:00:00Z',
+              thumbnails: {
+                high: { url: 'https://example.com/thumb.jpg' },
+              },
+              resourceId: { videoId: 'video-1' },
+              playlistId: 'playlist-123',
+            },
+          },
+        ],
+      },
+      'fallback',
+    );
+
+    expect(result.nextPageToken).toBe('next-1');
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      id: 'item-1',
+      videoId: 'video-1',
+      title: 'Saved video',
+      channelTitle: 'Channel',
+      thumbnailUrl: 'https://example.com/thumb.jpg',
+      playlistId: 'playlist-123',
+    });
+  });
+});

--- a/src/features/saved/youtube.ts
+++ b/src/features/saved/youtube.ts
@@ -1,0 +1,75 @@
+import type { SavedPlaylistItem } from './types';
+
+type PlaylistItemResponse = {
+  nextPageToken?: string;
+  items?: Array<{
+    id?: string;
+    snippet?: {
+      title?: string;
+      channelTitle?: string;
+      publishedAt?: string;
+      thumbnails?: {
+        high?: { url?: string };
+        medium?: { url?: string };
+        default?: { url?: string };
+      };
+      resourceId?: {
+        videoId?: string;
+      };
+      playlistId?: string;
+    };
+  }>;
+};
+
+type BuildUrlOptions = {
+  apiKey: string;
+  playlistId: string;
+  pageToken?: string;
+  maxResults?: number;
+};
+
+// Build the YouTube Data API URL in one place so we can test it easily.
+export function buildPlaylistItemsUrl({
+  apiKey,
+  playlistId,
+  pageToken,
+  maxResults = 50,
+}: BuildUrlOptions) {
+  const url = new URL('https://www.googleapis.com/youtube/v3/playlistItems');
+  url.searchParams.set('part', 'snippet');
+  url.searchParams.set('maxResults', String(maxResults));
+  url.searchParams.set('playlistId', playlistId);
+  url.searchParams.set('key', apiKey);
+
+  if (pageToken) {
+    url.searchParams.set('pageToken', pageToken);
+  }
+
+  return url.toString();
+}
+
+// Convert the API response into the smaller shape the UI needs.
+export function mapPlaylistResponse(
+  response: PlaylistItemResponse,
+  fallbackPlaylistId: string,
+): { items: SavedPlaylistItem[]; nextPageToken?: string } {
+  const items =
+    response.items?.map((item) => {
+      const snippet = item.snippet;
+      const thumbnails = snippet?.thumbnails;
+      const thumbnailUrl =
+        thumbnails?.high?.url || thumbnails?.medium?.url || thumbnails?.default?.url || null;
+
+      return {
+        id: item.id ?? '',
+        videoId: snippet?.resourceId?.videoId ?? '',
+        title: snippet?.title ?? 'Untitled video',
+        channelTitle: snippet?.channelTitle ?? 'Unknown channel',
+        thumbnailUrl,
+        publishedAt: snippet?.publishedAt ?? null,
+        playlistId: snippet?.playlistId ?? fallbackPlaylistId,
+      };
+    }) ?? [];
+
+  return { items, nextPageToken: response.nextPageToken };
+}

--- a/src/features/videos/components/video-card.test.tsx
+++ b/src/features/videos/components/video-card.test.tsx
@@ -48,8 +48,9 @@ const sample: VideoListItem = {
 
 describe('VideoCard', () => {
   it('renders link to video page', () => {
-    const { getByRole } = render(<VideoCard video={sample} />);
-    const link = getByRole('link');
-    expect(link).toHaveAttribute('href', '/video/abc123');
+    const { getAllByRole } = render(<VideoCard video={sample} />);
+    const links = getAllByRole('link');
+    expect(links[0]).toHaveAttribute('href', '/video/abc123');
+    expect(links[1]).toHaveAttribute('href', '/api/videos/abc123/download');
   });
 });

--- a/src/features/videos/components/video-card.tsx
+++ b/src/features/videos/components/video-card.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
-import type { VideoListItem} from '@/features/videos/api/nocodb';
+import type { VideoListItem } from '@/features/videos/api/nocodb';
 
 interface VideoCardProps {
   video: VideoListItem;
@@ -8,61 +9,73 @@ interface VideoCardProps {
 }
 
 export function VideoCard({ video, priority = false }: VideoCardProps) {
-
   const thumbnailUrl = video.ThumbHigh && typeof video.ThumbHigh === 'string' ? video.ThumbHigh : null;
 
   return (
-
-    <a href={`/video/${video.VideoID}`} className="block hover:shadow-lg transition-shadow duration-200 rounded-lg h-full">
-      <div
-        className="w-full flex flex-col h-full rounded-lg shadow-sm hover:shadow-md transition-shadow"
-        style={{
-          backgroundColor: 'var(--video-card-bg)',
-          color: 'var(--video-card-text)'
-        }}
+    <div className="h-full">
+      <Link
+        href={`/video/${video.VideoID}`}
+        className="block hover:shadow-lg transition-shadow duration-200 rounded-lg h-full"
       >
-        <div className="p-0 rounded-t-lg overflow-hidden">
-          {thumbnailUrl ? (
-            <div className="relative w-full aspect-video">
-              <Image
-                src={thumbnailUrl}
-                alt={`Thumbnail for ${video.Title}`}
-                fill
-                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-                className="object-cover object-top rounded-t-lg"
-                priority={priority}
-              />
-            </div>
-          ) : (
-            <div
-              className="relative w-full aspect-video flex items-center justify-center rounded-t-lg"
-              style={{ backgroundColor: 'var(--video-card-placeholder)' }}
-            >
-              <span style={{ color: 'var(--video-card-meta)' }}>No Thumbnail</span>
-            </div>
-          )}
-        </div>
-        <div className="p-2 flex-grow flex flex-col justify-between bg-neutral-800/50 rounded-b-lg">
-          <div>
-            <h3
-              className="text-base font-semibold line-clamp-2 mb-0.5"
-              style={{ color: 'var(--video-card-title)' }}
-              title={video.Title ?? undefined}
-            >
-              {video.Title}
-            </h3>
-            {video.Channel && (
-              <p
-                className="text-xs truncate mb-0.5"
-                style={{ color: 'var(--video-card-meta)' }}
-                title={video.Channel}
+        <div
+          className="w-full flex flex-col h-full rounded-lg shadow-sm hover:shadow-md transition-shadow"
+          style={{
+            backgroundColor: 'var(--video-card-bg)',
+            color: 'var(--video-card-text)'
+          }}
+        >
+          <div className="p-0 rounded-t-lg overflow-hidden">
+            {thumbnailUrl ? (
+              <div className="relative w-full aspect-video">
+                <Image
+                  src={thumbnailUrl}
+                  alt={`Thumbnail for ${video.Title}`}
+                  fill
+                  sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                  className="object-cover object-top rounded-t-lg"
+                  priority={priority}
+                />
+              </div>
+            ) : (
+              <div
+                className="relative w-full aspect-video flex items-center justify-center rounded-t-lg"
+                style={{ backgroundColor: 'var(--video-card-placeholder)' }}
               >
-                {video.Channel}
-              </p>
+                <span style={{ color: 'var(--video-card-meta)' }}>No Thumbnail</span>
+              </div>
             )}
           </div>
+          <div className="p-2 flex-grow flex flex-col justify-between bg-neutral-800/50 rounded-b-lg">
+            <div>
+              <h3
+                className="text-base font-semibold line-clamp-2 mb-0.5"
+                style={{ color: 'var(--video-card-title)' }}
+                title={video.Title ?? undefined}
+              >
+                {video.Title}
+              </h3>
+              {video.Channel && (
+                <p
+                  className="text-xs truncate mb-0.5"
+                  style={{ color: 'var(--video-card-meta)' }}
+                  title={video.Channel}
+                >
+                  {video.Channel}
+                </p>
+              )}
+            </div>
+          </div>
         </div>
+      </Link>
+      <div className="mt-2 flex justify-end">
+        {/* Simple download link so beginners can fetch the JSON in the browser */}
+        <a
+          className="text-xs text-neutral-300 hover:text-neutral-50 underline underline-offset-4"
+          href={`/api/videos/${video.VideoID}/download`}
+        >
+          Download JSON
+        </a>
       </div>
-    </a>
+    </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide an easy way for users to download the exact NocoDB payload for a video as JSON for inspection/export.  
- Add a second overview that surfaces videos from a YouTube playlist (e.g. a "Saved" playlist) so users can browse saved content alongside database summaries.  
- Support offline/quick access for the Saved playlist with a client-side cache bounded to product requirements (5 GB). 

### Description
- Add a per-video download endpoint and UI link to fetch and download the NocoDB record as JSON at `GET /api/videos/[videoId]/download` and a download link in the video card (`src/app/api/videos/[videoId]/download/route.ts`, `src/features/videos/components/video-card.tsx`).
- Implement Saved playlist integration: YouTube playlist helpers, mapping and URL builder, server proxy endpoint `GET /api/youtube/playlist`, and client components to fetch pages from the playlist API (`src/features/saved/youtube.ts`, `src/app/api/youtube/playlist/route.ts`, `src/features/saved/components/SavedPlaylistClient.tsx`).
- Add client-side IndexedDB schema and client for the Saved playlist with an approximate size estimator and a 5 GB cache limit (`src/features/saved/db/schema.ts`, `src/features/saved/db/client.ts`).
- Add small Saved UI pieces: `SavedVideoCard` and a toggle on the home page to switch between Summaries and Saved (`src/features/saved/components/SavedVideoCard.tsx`, `src/app/HomePageClient.tsx`).
- Add types and unit tests for the playlist helpers and update README to document new `YOUTUBE_API_KEY` and `YOUTUBE_SAVED_PLAYLIST_ID` environment variables (`src/features/saved/types.ts`, `src/features/saved/youtube.test.ts`, `README.md`).

### Testing
- Ran the unit tests for the new playlist helpers with `pnpm vitest run src/features/saved/youtube.test.ts`, which passed (2 tests).  
- No other automated test suites were executed in this change; existing test files were updated to expect the new download link.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f7ade19e88321ba4f60cc3f01fb73)