### PR TITLE
feat(downloads): add video/audio downloads and Saved playlist view with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A modern, responsive web application for browsing, searching, and interacting wi
   - **Filter Logic**: Simplified video filtering using configuration-driven approach with generic utilities
   - **Cache Management**: Fixed cache duplication issues and improved cache key consistency
   - All optimizations maintain backward compatibility while significantly improving code quality and performance
+- **Downloads**: Download video or audio files in selectable qualities (default 720p) directly from the video cards
+- **Saved Playlist View**: Toggle to a YouTube “Saved” playlist view with cached metadata (up to 5 GB cap)
 
 ## 🔍 Advanced Search System
 
@@ -113,6 +115,9 @@ If you use VS Code, the repository includes a preconfigured **dev container**. I
    NOCODB_TABLE_ID=your_table_id              # e.g. m1lyoeqptp7fq5z (opaque v2 id)
    # Optional: human-readable slug for diagnostics/logging
    # NOCODB_TABLE_NAME=youtubeTranscripts
+
+   # YouTube Saved playlist (required for the Saved toggle)
+   YOUTUBE_SAVED_PLAYLIST_ID=your_playlist_id
    ```
    > **Note for beginners:** The client now follows the official NocoDB v2 guidance (see the "Tables API" documentation and the StackOverflow discussion on PATCHing rows via `_rowId`). Provide the opaque `NOCODB_TABLE_ID` from the v2 UI/API and ensure `_rowId` support is enabled in your table. `NOCODB_TABLE_NAME` is optional and used only for diagnostics. All requests authenticate via the `xc-token` header.
 
@@ -134,6 +139,8 @@ NOCODB_PROJECT_ID=phk8vxq6f1ev08h
 NOCODB_TABLE_ID=m1lyoeqptp7fq5z
 # Optional diagnostic slug
 # NOCODB_TABLE_NAME=youtubeTranscripts
+# YouTube Saved playlist
+YOUTUBE_SAVED_PLAYLIST_ID=your_playlist_id
 ```
 
 If you do not have NocoDB running locally you can start one with Docker:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "ensure:video": "tsx scripts/ensure-video-state.ts"
   },
   "dependencies": {
+    "@distube/ytpl": "^1.2.4",
     "@radix-ui/react-select": "^2.2.4",
     "@radix-ui/react-slot": "^1.2.2",
     "axios": "^1.9.0",
@@ -31,6 +32,7 @@
     "remark-gfm": "^4.0.1",
     "swr": "^2.3.3",
     "tailwind-merge": "^3.3.0",
+    "ytdl-core": "^4.11.5",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@distube/ytpl':
+        specifier: ^1.2.4
+        version: 1.2.4
       '@radix-ui/react-select':
         specifier: ^2.2.4
         version: 2.2.4(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -56,6 +59,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.3.0
+      ytdl-core:
+        specifier: ^4.11.5
+        version: 4.11.5
       zod:
         specifier: ^3.24.4
         version: 3.24.4
@@ -249,6 +255,10 @@ packages:
 
   '@csstools/css-tokenizer@3.0.3':
     resolution: {integrity: sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==}
+    engines: {node: '>=18'}
+
+  '@distube/ytpl@1.2.4':
+    resolution: {integrity: sha512-jUHLapBX8tW+8DoUR7mFdYgeKjLFyJXzI662BfcYL4npD7tnxFLWB1w8m1R4GAhxqDufQOgP9IZgPsRwGo9Lfw==}
     engines: {node: '>=18'}
 
   '@emnapi/core@1.4.3':
@@ -2493,6 +2503,10 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
+  m3u8stream@0.8.6:
+    resolution: {integrity: sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==}
+    engines: {node: '>=12'}
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -2651,6 +2665,10 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  miniget@4.2.3:
+    resolution: {integrity: sha512-SjbDPDICJ1zT+ZvQwK0hUcRY4wxlhhNpHL9nJOB2MEAXRGagTljsO8MEDzQMTFf0Q8g4QNi8P9lEm/g7e+qgzA==}
+    engines: {node: '>=12'}
 
   minimatch@10.0.1:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
@@ -2997,6 +3015,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sax@1.4.4:
+    resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
+    engines: {node: '>=11.0.0'}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -3293,6 +3315,10 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
+  undici@6.23.0:
+    resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
+    engines: {node: '>=18.17'}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -3515,6 +3541,10 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  ytdl-core@4.11.5:
+    resolution: {integrity: sha512-27LwsW4n4nyNviRCO1hmr8Wr5J1wLLMawHCQvH8Fk0hiRqrxuIu028WzbJetiYH28K8XDbeinYW4/wcHQD1EXA==}
+    engines: {node: '>=12'}
+
   zod@3.24.4:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
@@ -3671,6 +3701,10 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.3
 
   '@csstools/css-tokenizer@3.0.3': {}
+
+  '@distube/ytpl@1.2.4':
+    dependencies:
+      undici: 6.23.0
 
   '@emnapi/core@1.4.3':
     dependencies:
@@ -5901,6 +5935,11 @@ snapshots:
 
   lz-string@1.5.0: {}
 
+  m3u8stream@0.8.6:
+    dependencies:
+      miniget: 4.2.3
+      sax: 1.4.4
+
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -6267,6 +6306,8 @@ snapshots:
       mime-db: 1.52.0
 
   min-indent@1.0.1: {}
+
+  miniget@4.2.3: {}
 
   minimatch@10.0.1:
     dependencies:
@@ -6673,6 +6714,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sax@1.4.4: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -7030,6 +7073,8 @@ snapshots:
 
   undici-types@6.19.8: {}
 
+  undici@6.23.0: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -7294,6 +7339,12 @@ snapshots:
   yallist@5.0.0: {}
 
   yocto-queue@0.1.0: {}
+
+  ytdl-core@4.11.5:
+    dependencies:
+      m3u8stream: 0.8.6
+      miniget: 4.2.3
+      sax: 1.4.4
 
   zod@3.24.4: {}
 

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { Settings } from 'lucide-react';
 import { SearchComponent } from '@/shared/components/search-component';
 import { PWAInstallPrompt } from '@/shared/components/pwa-install-prompt';
+import { Button } from '@/shared/components/ui/button';
+import { SavedList } from '@/features/saved/components/saved-list';
 
 /**
  * Client-side HomePage Component
@@ -13,6 +16,8 @@ import { PWAInstallPrompt } from '@/shared/components/pwa-install-prompt';
  * to intercept /api/videos requests and serve data from IndexedDB when offline.
  */
 export function HomePageClient() {
+  const [activeView, setActiveView] = useState<'summaries' | 'saved'>('summaries');
+
   return (
     <div className="min-h-screen bg-neutral-900 text-neutral-50 p-4 md:p-8 font-plex-sans">
       <div className="container mx-auto max-w-5xl">
@@ -21,6 +26,22 @@ export function HomePageClient() {
             Video Collection
           </h1>
           <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2 rounded-lg bg-neutral-800/80 p-1">
+              <Button
+                size="sm"
+                variant={activeView === 'summaries' ? 'secondary' : 'ghost'}
+                onClick={() => setActiveView('summaries')}
+              >
+                Summaries
+              </Button>
+              <Button
+                size="sm"
+                variant={activeView === 'saved' ? 'secondary' : 'ghost'}
+                onClick={() => setActiveView('saved')}
+              >
+                Saved
+              </Button>
+            </div>
             <Link
               href="/settings"
               className="p-2 rounded-lg hover:bg-neutral-800 transition-colors"
@@ -31,13 +52,16 @@ export function HomePageClient() {
           </div>
         </div>
 
-        <div className="search-component-wrapper">
-          {/* No initialVideos - let SearchComponent fetch client-side */}
-          <SearchComponent initialVideos={[]} />
-        </div>
+        {activeView === 'summaries' ? (
+          <div className="search-component-wrapper">
+            {/* No initialVideos - let SearchComponent fetch client-side */}
+            <SearchComponent initialVideos={[]} />
+          </div>
+        ) : (
+          <SavedList />
+        )}
 
-        {/* PWA Install Prompt */}
-        <PWAInstallPrompt />
+        {activeView === 'summaries' && <PWAInstallPrompt />}
       </div>
     </div>
   );

--- a/src/app/api/videos/[videoId]/download/route.ts
+++ b/src/app/api/videos/[videoId]/download/route.ts
@@ -1,0 +1,100 @@
+import { Readable } from 'node:stream';
+
+import { NextRequest, NextResponse } from 'next/server';
+import ytdl, { type videoFormat } from 'ytdl-core';
+
+import {
+  DEFAULT_AUDIO_QUALITY,
+  DEFAULT_VIDEO_QUALITY,
+  selectAudioFormat,
+  selectVideoFormat,
+} from '@/features/videos/utils/download-format';
+
+const buildVideoUrl = (videoId: string) => `https://www.youtube.com/watch?v=${videoId}`;
+
+const getAttachmentFilename = (options: {
+  videoId: string;
+  type: 'video' | 'audio';
+  quality: string;
+  container?: string | null;
+}) => {
+  const safeQuality = options.quality.replace(/[^a-z0-9]/gi, '_');
+  const extension = options.container ?? (options.type === 'audio' ? 'mp3' : 'mp4');
+  return `youtube-${options.videoId}-${options.type}-${safeQuality}.${extension}`;
+};
+
+/**
+ * Stream a YouTube video or audio file to the client.
+ * Uses ytdl-core to pick the best matching format and then streams it directly.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { videoId: string } },
+) {
+  const { videoId } = params;
+
+  if (!ytdl.validateID(videoId)) {
+    return NextResponse.json(
+      { success: false, error: 'Invalid video ID.' },
+      { status: 400 },
+    );
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const type = (searchParams.get('type') ?? 'video') as 'video' | 'audio';
+  const quality =
+    searchParams.get('quality') ??
+    (type === 'audio' ? DEFAULT_AUDIO_QUALITY : DEFAULT_VIDEO_QUALITY);
+
+  try {
+    const info = await ytdl.getInfo(buildVideoUrl(videoId));
+    const formats = info.formats;
+
+    let selectedFormat: videoFormat | undefined;
+
+    if (type === 'audio') {
+      const audioFormats = ytdl.filterFormats(formats, 'audioonly');
+      selectedFormat = selectAudioFormat(audioFormats, quality);
+    } else {
+      const videoFormats = ytdl.filterFormats(formats, 'videoandaudio');
+      selectedFormat = selectVideoFormat(videoFormats, quality);
+    }
+
+    if (!selectedFormat) {
+      return NextResponse.json(
+        { success: false, error: 'No matching format found.' },
+        { status: 404 },
+      );
+    }
+
+    const mimeType = selectedFormat.mimeType?.split(';')[0] ?? 'application/octet-stream';
+    const filename = getAttachmentFilename({
+      videoId,
+      type,
+      quality,
+      container: selectedFormat.container,
+    });
+    const downloadStream = ytdl.downloadFromInfo(info, {
+      format: selectedFormat,
+    });
+    const webStream = Readable.toWeb(downloadStream) as ReadableStream<Uint8Array>;
+
+    return new NextResponse(webStream, {
+      headers: {
+        'Content-Type': mimeType,
+        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    console.error('Download error:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to start download.',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/youtube/saved/route.ts
+++ b/src/app/api/youtube/saved/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import ytpl from '@distube/ytpl';
+
+import type { SavedVideo } from '@/features/saved/types';
+import { SAVED_CACHE_LIMIT_BYTES } from '@/features/saved/db/schema';
+
+const PLAYLIST_ID = process.env.YOUTUBE_SAVED_PLAYLIST_ID;
+
+const mapPlaylistItem = (item: {
+  id: string;
+  title: string;
+  url: string;
+  shortUrl?: string;
+  duration?: string | null;
+  bestThumbnail?: { url?: string | null } | null;
+  thumbnail?: string | null;
+  author?: { name?: string | null } | null;
+}) => {
+  const now = new Date().toISOString();
+  return {
+    id: item.id,
+    title: item.title,
+    url: item.shortUrl || item.url,
+    duration: item.duration ?? null,
+    channel: item.author?.name ?? null,
+    thumbnailUrl: item.bestThumbnail?.url ?? item.thumbnail ?? null,
+    addedAt: now,
+  } satisfies SavedVideo;
+};
+
+/**
+ * Fetch the "Saved" YouTube playlist for the authenticated account.
+ * The playlist ID must be provided via environment variable.
+ */
+export async function GET() {
+  if (!PLAYLIST_ID) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Missing YOUTUBE_SAVED_PLAYLIST_ID environment variable.',
+      },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const playlist = await ytpl(PLAYLIST_ID, { limit: 200 });
+    const items = playlist.items.map(mapPlaylistItem);
+
+    return NextResponse.json({
+      success: true,
+      items,
+      playlistTitle: playlist.title,
+      cacheLimitBytes: SAVED_CACHE_LIMIT_BYTES,
+    });
+  } catch (error) {
+    console.error('Failed to fetch saved playlist:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to fetch saved playlist.',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/features/saved/components/saved-list.tsx
+++ b/src/features/saved/components/saved-list.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { SavedVideoCard } from './saved-video-card';
+import type { SavedVideo } from '../types';
+import {
+  getCachedSavedVideos,
+  getSavedCacheMetadata,
+  replaceSavedVideos,
+} from '../db/client';
+
+interface SavedListResponse {
+  success: boolean;
+  items: SavedVideo[];
+  playlistTitle?: string;
+  cacheLimitBytes: number;
+  error?: string;
+}
+
+const formatBytes = (bytes: number) => {
+  if (bytes === 0) {
+    return '0 B';
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const base = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, base);
+  return `${value.toFixed(1)} ${units[base]}`;
+};
+
+/**
+ * Fetches the "Saved" playlist and displays it with caching for offline use.
+ */
+export function SavedList() {
+  const [savedVideos, setSavedVideos] = useState<SavedVideo[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [playlistTitle, setPlaylistTitle] = useState<string | null>(null);
+  const [cacheMeta, setCacheMeta] = useState<{ totalBytes: number; updatedAt: string | null }>({
+    totalBytes: 0,
+    updatedAt: null,
+  });
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadCached = async () => {
+      try {
+        const [cached, metadata] = await Promise.all([
+          getCachedSavedVideos(),
+          getSavedCacheMetadata(),
+        ]);
+        if (isMounted && cached.length > 0) {
+          setSavedVideos(cached);
+          setCacheMeta(metadata);
+        }
+      } catch (cacheError) {
+        console.warn('Failed to load saved cache:', cacheError);
+      }
+    };
+
+    const fetchSaved = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch('/api/youtube/saved');
+        const data = (await response.json()) as SavedListResponse;
+
+        if (!data.success) {
+          throw new Error(data.error || 'Failed to load saved playlist.');
+        }
+
+        if (!isMounted) {
+          return;
+        }
+
+        setSavedVideos(data.items);
+        setPlaylistTitle(data.playlistTitle ?? 'Saved');
+
+        const cacheResult = await replaceSavedVideos(data.items);
+        setCacheMeta({
+          totalBytes: cacheResult.totalBytes,
+          updatedAt: new Date().toISOString(),
+        });
+      } catch (fetchError) {
+        if (!isMounted) {
+          return;
+        }
+
+        const message = fetchError instanceof Error ? fetchError.message : 'Unknown error.';
+        setError(message);
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadCached();
+    void fetchSaved();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-xl font-semibold text-neutral-100">
+            {playlistTitle ?? 'Saved'} Playlist
+          </h2>
+          <p className="text-sm text-neutral-400">
+            Cache size: {formatBytes(cacheMeta.totalBytes)} · Last updated:{' '}
+            {cacheMeta.updatedAt ? new Date(cacheMeta.updatedAt).toLocaleString() : '—'}
+          </p>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-500/50 bg-red-500/10 p-3 text-sm text-red-200">
+          {error}
+        </div>
+      )}
+
+      {isLoading && savedVideos.length === 0 ? (
+        <p className="text-sm text-neutral-400">Loading saved videos…</p>
+      ) : savedVideos.length === 0 ? (
+        <p className="text-sm text-neutral-400">No saved videos found yet.</p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {savedVideos.map(video => (
+            <SavedVideoCard key={video.id} video={video} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/saved/components/saved-video-card.tsx
+++ b/src/features/saved/components/saved-video-card.tsx
@@ -1,24 +1,24 @@
 'use client';
 
 import Image from 'next/image';
-import Link from 'next/link';
 
-import { DownloadControls } from './download-controls';
-import type { VideoListItem } from '@/features/videos/api/nocodb';
+import { DownloadControls } from '@/features/videos/components/download-controls';
+import type { SavedVideo } from '../types';
 
-interface VideoCardProps {
-  video: VideoListItem;
-  priority?: boolean;
+interface SavedVideoCardProps {
+  video: SavedVideo;
 }
 
-export function VideoCard({ video, priority = false }: VideoCardProps) {
-  const thumbnailUrl =
-    video.ThumbHigh && typeof video.ThumbHigh === 'string' ? video.ThumbHigh : null;
-
+/**
+ * Card UI for videos coming from the Saved playlist.
+ */
+export function SavedVideoCard({ video }: SavedVideoCardProps) {
   return (
     <div className="flex h-full flex-col rounded-lg shadow-sm transition-shadow hover:shadow-md">
-      <Link
-        href={`/video/${video.VideoID}`}
+      <a
+        href={video.url}
+        target="_blank"
+        rel="noreferrer"
         className="block h-full rounded-lg hover:shadow-lg transition-shadow duration-200"
       >
         <div
@@ -29,15 +29,14 @@ export function VideoCard({ video, priority = false }: VideoCardProps) {
           }}
         >
           <div className="p-0 rounded-t-lg overflow-hidden">
-            {thumbnailUrl ? (
+            {video.thumbnailUrl ? (
               <div className="relative w-full aspect-video">
                 <Image
-                  src={thumbnailUrl}
-                  alt={`Thumbnail for ${video.Title}`}
+                  src={video.thumbnailUrl}
+                  alt={`Thumbnail for ${video.title}`}
                   fill
                   sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                   className="object-cover object-top rounded-t-lg"
-                  priority={priority}
                 />
               </div>
             ) : (
@@ -54,25 +53,33 @@ export function VideoCard({ video, priority = false }: VideoCardProps) {
               <h3
                 className="text-base font-semibold line-clamp-2 mb-0.5"
                 style={{ color: 'var(--video-card-title)' }}
-                title={video.Title ?? undefined}
+                title={video.title}
               >
-                {video.Title}
+                {video.title}
               </h3>
-              {video.Channel && (
+              {video.channel && (
                 <p
                   className="text-xs truncate mb-0.5"
                   style={{ color: 'var(--video-card-meta)' }}
-                  title={video.Channel}
+                  title={video.channel}
                 >
-                  {video.Channel}
+                  {video.channel}
+                </p>
+              )}
+              {video.duration && (
+                <p
+                  className="text-xs truncate mb-0.5"
+                  style={{ color: 'var(--video-card-meta)' }}
+                >
+                  {video.duration}
                 </p>
               )}
             </div>
           </div>
         </div>
-      </Link>
+      </a>
       <div className="bg-neutral-900 px-3 py-2 rounded-b-lg border-t border-neutral-800">
-        <DownloadControls videoId={video.VideoID} title={video.Title} />
+        <DownloadControls videoId={video.id} title={video.title} />
       </div>
     </div>
   );

--- a/src/features/saved/db/client.ts
+++ b/src/features/saved/db/client.ts
@@ -1,0 +1,83 @@
+import { openDB } from 'idb';
+
+import type { SavedVideo } from '../types';
+import {
+  SAVED_CACHE_LIMIT_BYTES,
+  SAVED_DB_NAME,
+  SAVED_DB_VERSION,
+  type SavedDBSchema,
+} from './schema';
+
+const dbPromise = openDB<SavedDBSchema>(SAVED_DB_NAME, SAVED_DB_VERSION, {
+  upgrade(database) {
+    const store = database.createObjectStore('savedVideos', { keyPath: 'id' });
+    store.createIndex('by-addedAt', 'addedAt');
+
+    database.createObjectStore('metadata');
+  },
+});
+
+const estimateSizeBytes = (video: SavedVideo) =>
+  new TextEncoder().encode(JSON.stringify(video)).length;
+
+/**
+ * Fetch saved videos from IndexedDB so we can show cached data quickly.
+ */
+export const getCachedSavedVideos = async () => {
+  const db = await dbPromise;
+  return db.getAll('savedVideos');
+};
+
+/**
+ * Replace the cached saved playlist with the latest data.
+ * We keep the newest items if the cache would exceed the 5 GB cap.
+ */
+export const replaceSavedVideos = async (videos: SavedVideo[]) => {
+  const db = await dbPromise;
+  const sorted = [...videos].sort(
+    (a, b) => new Date(b.addedAt).getTime() - new Date(a.addedAt).getTime(),
+  );
+
+  const kept: SavedVideo[] = [];
+  let totalBytes = 0;
+
+  for (const video of sorted) {
+    const size = estimateSizeBytes(video);
+    if (totalBytes + size > SAVED_CACHE_LIMIT_BYTES) {
+      continue;
+    }
+
+    kept.push(video);
+    totalBytes += size;
+  }
+
+  const tx = db.transaction(['savedVideos', 'metadata'], 'readwrite');
+  await tx.objectStore('savedVideos').clear();
+
+  for (const video of kept) {
+    await tx.objectStore('savedVideos').put(video);
+  }
+
+  await tx.objectStore('metadata').put(totalBytes, 'savedCacheBytes');
+  await tx.objectStore('metadata').put(new Date().toISOString(), 'savedCacheUpdatedAt');
+
+  await tx.done;
+
+  return { saved: kept, totalBytes };
+};
+
+/**
+ * Return the current cache metadata for UI display.
+ */
+export const getSavedCacheMetadata = async () => {
+  const db = await dbPromise;
+  const [totalBytes, updatedAt] = await Promise.all([
+    db.get('metadata', 'savedCacheBytes'),
+    db.get('metadata', 'savedCacheUpdatedAt'),
+  ]);
+
+  return {
+    totalBytes: typeof totalBytes === 'number' ? totalBytes : 0,
+    updatedAt: typeof updatedAt === 'string' ? updatedAt : null,
+  };
+};

--- a/src/features/saved/db/schema.ts
+++ b/src/features/saved/db/schema.ts
@@ -1,0 +1,27 @@
+import type { DBSchema } from 'idb';
+
+import type { SavedVideo } from '../types';
+
+/**
+ * IndexedDB schema for the Saved playlist cache.
+ * This database is separate from the offline video cache to keep concerns split.
+ */
+export interface SavedDBSchema extends DBSchema {
+  savedVideos: {
+    key: string; // YouTube video ID
+    value: SavedVideo;
+    indexes: {
+      'by-addedAt': string;
+    };
+  };
+  metadata: {
+    key: string;
+    value: unknown;
+  };
+}
+
+export const SAVED_DB_NAME = 'yt-viewer-saved';
+export const SAVED_DB_VERSION = 1;
+
+// 5 GB cache cap for Saved playlist metadata + thumbnails.
+export const SAVED_CACHE_LIMIT_BYTES = 5 * 1024 * 1024 * 1024;

--- a/src/features/saved/types.ts
+++ b/src/features/saved/types.ts
@@ -1,0 +1,9 @@
+export type SavedVideo = {
+  id: string;
+  title: string;
+  channel?: string | null;
+  duration?: string | null;
+  url: string;
+  thumbnailUrl?: string | null;
+  addedAt: string;
+};

--- a/src/features/videos/components/download-controls.tsx
+++ b/src/features/videos/components/download-controls.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import type { MouseEvent } from 'react';
+import { useMemo, useState } from 'react';
+
+import { Button } from '@/shared/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/components/ui/select';
+import {
+  DEFAULT_AUDIO_QUALITY,
+  DEFAULT_VIDEO_QUALITY,
+  type DownloadType,
+} from '@/features/videos/utils/download-format';
+
+const VIDEO_QUALITY_OPTIONS = ['1080p', '720p', '480p', '360p'] as const;
+const AUDIO_QUALITY_OPTIONS = ['high', 'medium', 'low'] as const;
+
+interface DownloadControlsProps {
+  videoId: string | null;
+  title?: string | null;
+}
+
+/**
+ * Download controls for video/audio with selectable quality.
+ * This component stays client-side because it manages user interaction state.
+ */
+export function DownloadControls({ videoId, title }: DownloadControlsProps) {
+  const [downloadType, setDownloadType] = useState<DownloadType>('video');
+  const [quality, setQuality] = useState(DEFAULT_VIDEO_QUALITY);
+
+  const qualityOptions = useMemo(() => {
+    return downloadType === 'video'
+      ? VIDEO_QUALITY_OPTIONS
+      : AUDIO_QUALITY_OPTIONS;
+  }, [downloadType]);
+
+  const isDownloadDisabled = !videoId;
+
+  const downloadUrl = useMemo(() => {
+    if (!videoId) {
+      return '#';
+    }
+
+    const params = new URLSearchParams({
+      type: downloadType,
+      quality,
+    });
+
+    return `/api/videos/${videoId}/download?${params.toString()}`;
+  }, [videoId, downloadType, quality]);
+
+  const handleDownloadClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (isDownloadDisabled) {
+      event.preventDefault();
+    }
+  };
+
+  const handleTypeChange = (value: DownloadType) => {
+    setDownloadType(value);
+    setQuality(value === 'video' ? DEFAULT_VIDEO_QUALITY : DEFAULT_AUDIO_QUALITY);
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Select value={downloadType} onValueChange={handleTypeChange}>
+        <SelectTrigger className="w-[140px]" size="sm" aria-label="Download type">
+          <SelectValue placeholder="Type" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="video">Video</SelectItem>
+          <SelectItem value="audio">Audio</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <Select value={quality} onValueChange={setQuality}>
+        <SelectTrigger className="w-[120px]" size="sm" aria-label="Quality">
+          <SelectValue placeholder="Quality" />
+        </SelectTrigger>
+        <SelectContent>
+          {qualityOptions.map(option => (
+            <SelectItem key={option} value={option}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Button asChild size="sm" disabled={isDownloadDisabled}>
+        <a
+          href={downloadUrl}
+          download
+          aria-disabled={isDownloadDisabled}
+          aria-label={`Download ${title ?? 'video'}`}
+          onClick={handleDownloadClick}
+        >
+          Download
+        </a>
+      </Button>
+    </div>
+  );
+}

--- a/src/features/videos/components/video-card.test.tsx
+++ b/src/features/videos/components/video-card.test.tsx
@@ -48,8 +48,15 @@ const sample: VideoListItem = {
 
 describe('VideoCard', () => {
   it('renders link to video page', () => {
+    const { getAllByRole } = render(<VideoCard video={sample} />);
+    const links = getAllByRole('link');
+    const videoLink = links.find(link => link.getAttribute('href') === '/video/abc123');
+    expect(videoLink).toBeTruthy();
+  });
+
+  it('renders a download button', () => {
     const { getByRole } = render(<VideoCard video={sample} />);
-    const link = getByRole('link');
-    expect(link).toHaveAttribute('href', '/video/abc123');
+    const button = getByRole('link', { name: /download test video/i });
+    expect(button).toHaveAttribute('href', expect.stringContaining('/api/videos/abc123/download'));
   });
 });

--- a/src/features/videos/utils/download-format.test.ts
+++ b/src/features/videos/utils/download-format.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  selectAudioFormat,
+  selectVideoFormat,
+} from './download-format';
+
+type TestFormat = {
+  id: string;
+  qualityLabel?: string | null;
+  height?: number | null;
+  audioBitrate?: number | null;
+};
+
+describe('download format selection', () => {
+  it('selects a matching video quality label when available', () => {
+    const formats: TestFormat[] = [
+      { id: 'a', qualityLabel: '360p', height: 360 },
+      { id: 'b', qualityLabel: '720p', height: 720 },
+    ];
+
+    const selected = selectVideoFormat(formats, '720p');
+
+    expect(selected?.id).toBe('b');
+  });
+
+  it('falls back to the highest resolution when no match exists', () => {
+    const formats: TestFormat[] = [
+      { id: 'a', qualityLabel: '360p', height: 360 },
+      { id: 'b', qualityLabel: '1080p', height: 1080 },
+    ];
+
+    const selected = selectVideoFormat(formats, '480p');
+
+    expect(selected?.id).toBe('b');
+  });
+
+  it('selects audio quality by bitrate level', () => {
+    const formats: TestFormat[] = [
+      { id: 'low', audioBitrate: 64 },
+      { id: 'medium', audioBitrate: 128 },
+      { id: 'high', audioBitrate: 256 },
+    ];
+
+    expect(selectAudioFormat(formats, 'low')?.id).toBe('low');
+    expect(selectAudioFormat(formats, 'medium')?.id).toBe('medium');
+    expect(selectAudioFormat(formats, 'high')?.id).toBe('high');
+  });
+});

--- a/src/features/videos/utils/download-format.ts
+++ b/src/features/videos/utils/download-format.ts
@@ -1,0 +1,77 @@
+export const DEFAULT_VIDEO_QUALITY = '720p';
+export const DEFAULT_AUDIO_QUALITY = 'high';
+
+export type DownloadType = 'video' | 'audio';
+
+export type SimpleFormat = {
+  qualityLabel?: string | null;
+  height?: number | null;
+  audioBitrate?: number | null;
+};
+
+const AUDIO_QUALITY_ORDER = ['low', 'medium', 'high'] as const;
+
+type AudioQuality = (typeof AUDIO_QUALITY_ORDER)[number];
+
+const normalizeAudioQuality = (value: string): AudioQuality => {
+  if (value === 'low' || value === 'medium' || value === 'high') {
+    return value;
+  }
+  return DEFAULT_AUDIO_QUALITY;
+};
+
+/**
+ * Select the best video format that matches a requested quality label.
+ * Falls back to the highest resolution if no exact match is found.
+ */
+export const selectVideoFormat = <T extends SimpleFormat>(
+  formats: T[],
+  qualityLabel: string,
+): T | undefined => {
+  if (formats.length === 0) {
+    return undefined;
+  }
+
+  const normalizedLabel = qualityLabel.toLowerCase();
+  const exactMatch = formats.find(format =>
+    format.qualityLabel?.toLowerCase() === normalizedLabel,
+  );
+
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  return [...formats]
+    .sort((a, b) => (b.height ?? 0) - (a.height ?? 0))
+    .find(format => (format.height ?? 0) > 0);
+};
+
+/**
+ * Select an audio format based on a friendly quality label.
+ * - high: highest bitrate
+ * - medium: middle bitrate
+ * - low: lowest bitrate
+ */
+export const selectAudioFormat = <T extends SimpleFormat>(
+  formats: T[],
+  audioQuality: string,
+): T | undefined => {
+  if (formats.length === 0) {
+    return undefined;
+  }
+
+  const normalizedQuality = normalizeAudioQuality(audioQuality);
+  const sorted = [...formats].sort(
+    (a, b) => (a.audioBitrate ?? 0) - (b.audioBitrate ?? 0),
+  );
+
+  if (normalizedQuality === 'low') {
+    return sorted[0];
+  }
+
+  if (normalizedQuality === 'medium') {
+    return sorted[Math.floor(sorted.length / 2)];
+  }
+
+  return sorted[sorted.length - 1];
+};


### PR DESCRIPTION
### Motivation
- Add the ability to download media (video or audio) in selectable qualities (default `720p`) for videos shown in the app. 
- Provide a second source of videos from a YouTube account playlist (example: "Saved") and a dedicated view for that playlist. 
- Cache Saved-playlist metadata client-side with a larger cap (max 5 GB) so the list can be used offline/fast without impacting the existing offline video cache limits. 

### Description
- Added client download controls and UI integration: `src/features/videos/components/download-controls.tsx` and integrated into video cards (`src/features/videos/components/video-card.tsx`) to choose `video`/`audio` and quality. 
- Implemented a streaming download API route using `ytdl-core` at `GET /api/videos/[videoId]/download` which selects formats via the new helper `src/features/videos/utils/download-format.ts`. 
- Implemented Saved-playlist retrieval and caching: server route `GET /api/youtube/saved` (uses `@distube/ytpl`), client Saved list UI `src/features/saved/components/saved-list.tsx`, Saved card `saved-video-card.tsx`, and IndexedDB client `src/features/saved/db/*` with a `SAVED_CACHE_LIMIT_BYTES` cap set to 5 GB. 
- Minor UX and docs: Home page toggle between `Summaries` and `Saved` in `src/app/HomePageClient.tsx`, README updated with `YOUTUBE_SAVED_PLAYLIST_ID` and download notes, and small tests added/updated for format selection and VideoCard behavior. 

### Testing
- Ran the automated test suite with `pnpm test` and all tests passed successfully (`31` tests passed). 
- New unit tests include `src/features/videos/utils/download-format.test.ts` (format selection) and updated `src/features/videos/components/video-card.test.tsx` to cover the download link.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f8109b7148321b6c47a7dd9f05e36)